### PR TITLE
0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.5.0
+
+Based on [android-maps-compose 8.2.0](https://github.com/googlemaps/android-maps-compose).
+
+**SDK Versions:**
+- Google Maps iOS SDK: 10.8.0
+- Google Play Services Maps: 20.0.0
+
+### Features
+
+- **`TileOverlay` composable** - Cross-platform tile overlay support wrapping `TileProvider`/`TileOverlay` on Android and `GMSSyncTileLayer` on iOS. Includes `TileOverlayState` for cache management, with fadeIn, transparency, visibility, and zIndex properties.
+- **`clusterItemDecoration`** - New parameter on all `Clustering` overloads for rendering additional map content (circles, polylines, etc.) alongside each unclustered item, matching android-maps-compose 8.2.0
+
+### Breaking Changes
+
+- **`clusterItemDecoration` signature** - Changed from `(T) -> Unit` to `(T, LatLng) -> Unit` so decorations receive the animated position during cluster transitions
+
+### Other Changes
+
+- Updated maps-compose to 8.2.0, Compose Multiplatform to 1.10.2, AGP to 9.1.0
+
 ## 0.4.0
 
 Based on [android-maps-compose 8.1.0](https://github.com/googlemaps/android-maps-compose).

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ This table shows feature compatibility between `android-maps-compose` and this l
 | Circle | Yes | Yes | |
 | Circle pattern | Yes | Partial | Android only |
 | GroundOverlay | Yes | Yes | |
-| TileOverlay | Yes | No | |
+| TileOverlay | Yes | Yes | |
 
 ### Advanced Features
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Add the dependency to your `build.gradle.kts`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("eu.buney.maps:kmp-maps-compose:0.4.0")
+            implementation("eu.buney.maps:kmp-maps-compose:0.5.0")
 
             // Optional: clustering utilities
-            implementation("eu.buney.maps:kmp-maps-compose-utils:0.4.0")
+            implementation("eu.buney.maps:kmp-maps-compose-utils:0.5.0")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 kmp-maps-compose = "0.5.0-SNAPSHOT"
 kotlin = "2.3.10"
-compose = "1.10.1"
-agp = "9.0.1"
+compose = "1.10.2"
+agp = "9.1.0"
 maps-compose = "8.1.0"
 # play-services-maps version should match maps-compose transitive dependency:
 # maps-compose 8.0.0 -> maps-ktx 6.0.0 -> play-services-maps 20.0.0
@@ -10,9 +10,9 @@ play-services-maps = "20.0.0"
 google-maps-ios = "10.8.0"
 activity-compose = "1.12.4"
 androidx-core = "1.17.0"
-kermit = "2.0.8"
+kermit = "2.1.0"
 buildkonfig = "0.17.1"
-spmForKmp = "1.4.8"
+spmForKmp = "1.4.9"
 vanniktechMavenPublish = "0.36.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,9 @@ kmp-maps-compose = "0.5.0-SNAPSHOT"
 kotlin = "2.3.10"
 compose = "1.10.2"
 agp = "9.1.0"
-maps-compose = "8.1.0"
+maps-compose = "8.2.0"
 # play-services-maps version should match maps-compose transitive dependency:
-# maps-compose 8.0.0 -> maps-ktx 6.0.0 -> play-services-maps 20.0.0
+# maps-compose 8.2.0 -> maps-ktx 6.0.0 -> play-services-maps 20.0.0
 play-services-maps = "20.0.0"
 google-maps-ios = "10.8.0"
 activity-compose = "1.12.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmp-maps-compose = "0.4.0"
+kmp-maps-compose = "0.5.0-SNAPSHOT"
 kotlin = "2.3.10"
 compose = "1.10.1"
 agp = "9.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmp-maps-compose = "0.5.0-SNAPSHOT"
+kmp-maps-compose = "0.5.0"
 kotlin = "2.3.10"
 compose = "1.10.2"
 agp = "9.1.0"

--- a/kmp-maps-compose-utils/src/commonMain/kotlin/eu/buney/maps/utils/clustering/Clustering.kt
+++ b/kmp-maps-compose-utils/src/commonMain/kotlin/eu/buney/maps/utils/clustering/Clustering.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import eu.buney.maps.GoogleMapComposable
 import eu.buney.maps.LatLng
 import eu.buney.maps.Marker
 import eu.buney.maps.MarkerComposable
@@ -39,6 +40,7 @@ fun <T : ClusterItem> Clustering(
     exitAnimationSpec: FiniteAnimationSpec<Float> = DefaultAnimationSpec,
     clusterContent: (@Composable (Cluster<T>) -> Unit)? = null,
     clusterItemContent: (@Composable (T) -> Unit)? = null,
+    clusterItemDecoration: @Composable @GoogleMapComposable (T, LatLng) -> Unit = { _, _ -> },
 ) {
     val cameraPositionState = currentCameraPositionState
     var clusters by remember { mutableStateOf<Set<Cluster<T>>>(emptySet()) }
@@ -137,6 +139,7 @@ fun <T : ClusterItem> Clustering(
                     },
                 )
             }
+            clusterItemDecoration(item, position)
         },
     )
 }
@@ -172,6 +175,7 @@ fun <T : ClusterItem> Clustering(
     exitAnimationSpec: FiniteAnimationSpec<Float> = DefaultAnimationSpec,
     clusterContent: (@Composable (Cluster<T>) -> Unit)? = null,
     clusterItemContent: (@Composable (T) -> Unit)? = null,
+    clusterItemDecoration: @Composable @GoogleMapComposable (T, LatLng) -> Unit = { _, _ -> },
 ) {
     Clustering(
         items = items,
@@ -183,6 +187,7 @@ fun <T : ClusterItem> Clustering(
         exitAnimationSpec = exitAnimationSpec,
         clusterContent = clusterContent,
         clusterItemContent = clusterItemContent,
+        clusterItemDecoration = clusterItemDecoration,
         onClusterManager = null,
     )
 }
@@ -202,6 +207,7 @@ fun <T : ClusterItem> Clustering(
     exitAnimationSpec: FiniteAnimationSpec<Float> = DefaultAnimationSpec,
     clusterContent: (@Composable (Cluster<T>) -> Unit)? = null,
     clusterItemContent: (@Composable (T) -> Unit)? = null,
+    clusterItemDecoration: @Composable @GoogleMapComposable (T, LatLng) -> Unit = { _, _ -> },
     onClusterManager: ((ClusterManager<T>) -> Unit)?,
 ) {
     val clusterManager = rememberClusterManager<T>()
@@ -221,5 +227,6 @@ fun <T : ClusterItem> Clustering(
         exitAnimationSpec = exitAnimationSpec,
         clusterContent = clusterContent,
         clusterItemContent = clusterItemContent,
+        clusterItemDecoration = clusterItemDecoration,
     )
 }

--- a/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/BitmapDescriptor.android.kt
+++ b/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/BitmapDescriptor.android.kt
@@ -1,8 +1,6 @@
 package eu.buney.maps
 
-import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import java.nio.ByteBuffer
 import com.google.android.gms.maps.model.BitmapDescriptor as GoogleBitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory as GoogleBitmapDescriptorFactory
 
@@ -20,20 +18,7 @@ actual class BitmapDescriptor(
 actual object BitmapDescriptorFactory {
 
     actual fun fromBytes(bytes: ByteArray, width: Int, height: Int): BitmapDescriptor {
-        require(bytes.size == width * height * 4) {
-            "Byte array size (${bytes.size}) must equal width * height * 4 (${width * height * 4})"
-        }
-        // convert from ARGB byte order to RGBA byte order
-        // Android's copyPixelsFromBuffer expects RGBA, despite ARGB_8888 config name
-        val rgbaBytes = ByteArray(bytes.size)
-        for (i in bytes.indices step 4) {
-            rgbaBytes[i] = bytes[i + 1]     // R (was at index 1)
-            rgbaBytes[i + 1] = bytes[i + 2] // G (was at index 2)
-            rgbaBytes[i + 2] = bytes[i + 3] // B (was at index 3)
-            rgbaBytes[i + 3] = bytes[i]     // A (was at index 0)
-        }
-        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-        bitmap.copyPixelsFromBuffer(ByteBuffer.wrap(rgbaBytes))
+        val bitmap = argbBytesToBitmap(bytes, width, height)
         return BitmapDescriptor(GoogleBitmapDescriptorFactory.fromBitmap(bitmap))
     }
 

--- a/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/ImageConversions.android.kt
+++ b/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/ImageConversions.android.kt
@@ -1,0 +1,41 @@
+package eu.buney.maps
+
+import android.graphics.Bitmap
+import androidx.core.graphics.createBitmap
+import java.io.ByteArrayOutputStream
+
+/**
+ * Converts raw ARGB pixel bytes into a [Bitmap].
+ *
+ * @param bytes Raw pixel data — 4 bytes per pixel: alpha, red, green, blue.
+ * @param width Image width in pixels.
+ * @param height Image height in pixels.
+ */
+internal fun argbBytesToBitmap(bytes: ByteArray, width: Int, height: Int): Bitmap {
+    require(bytes.size == width * height * 4) {
+        "Byte array size (${bytes.size}) must equal width * height * 4 (${width * height * 4})"
+    }
+    val pixelCount = width * height
+    val colors = IntArray(pixelCount)
+    for (i in 0 until pixelCount) {
+        val base = i * 4
+        val a = bytes[base].toInt() and 0xFF
+        val r = bytes[base + 1].toInt() and 0xFF
+        val g = bytes[base + 2].toInt() and 0xFF
+        val b = bytes[base + 3].toInt() and 0xFF
+        colors[i] = (a shl 24) or (r shl 16) or (g shl 8) or b
+    }
+    val bitmap = createBitmap(width, height)
+    bitmap.setPixels(colors, 0, width, 0, 0, width, height)
+    return bitmap
+}
+
+/**
+ * Compresses this [Bitmap] to PNG format and returns the encoded bytes.
+ */
+internal fun Bitmap.compressToPng(): ByteArray {
+    return ByteArrayOutputStream().use { stream ->
+        compress(Bitmap.CompressFormat.PNG, 100, stream)
+        stream.toByteArray()
+    }
+}

--- a/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/NativeTileOverlay.android.kt
+++ b/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/NativeTileOverlay.android.kt
@@ -1,0 +1,5 @@
+package eu.buney.maps
+
+import com.google.android.gms.maps.model.TileOverlay
+
+actual typealias NativeTileOverlay = TileOverlay

--- a/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/TileOverlay.android.kt
+++ b/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/TileOverlay.android.kt
@@ -1,0 +1,73 @@
+package eu.buney.maps
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import com.google.android.gms.maps.model.Tile as GoogleTile
+import com.google.android.gms.maps.model.TileProvider as GoogleTileProvider
+import com.google.maps.android.compose.TileOverlay as AndroidTileOverlay
+import com.google.maps.android.compose.TileOverlayState as AndroidTileOverlayState
+import com.google.maps.android.compose.rememberTileOverlayState as androidRememberTileOverlayState
+
+/**
+ * Android implementation of [Tile].
+ * Wraps a Google Maps SDK [GoogleTile] containing encoded image bytes.
+ */
+actual class Tile(val googleTile: GoogleTile)
+
+/**
+ * Android implementation of [TileFactory].
+ */
+actual object TileFactory {
+    actual fun fromBytes(bytes: ByteArray, width: Int, height: Int): Tile {
+        val bitmap = argbBytesToBitmap(bytes, width, height)
+        val pngBytes = bitmap.compressToPng()
+        bitmap.recycle()
+        return Tile(GoogleTile(width, height, pngBytes))
+    }
+
+    actual fun fromEncodedImage(data: ByteArray, width: Int, height: Int): Tile {
+        return Tile(GoogleTile(width, height, data))
+    }
+}
+
+/**
+ * Android implementation of [TileOverlayState].
+ * Wraps the android-maps-compose [AndroidTileOverlayState].
+ */
+@Stable
+actual class TileOverlayState actual constructor() {
+    internal val androidState = AndroidTileOverlayState()
+
+    actual fun clearTileCache() {
+        androidState.clearTileCache()
+    }
+}
+
+@Composable
+@GoogleMapComposable
+actual fun TileOverlay(
+    tileProvider: TileProvider,
+    state: TileOverlayState,
+    fadeIn: Boolean,
+    transparency: Float,
+    visible: Boolean,
+    zIndex: Float,
+    onClick: (NativeTileOverlay) -> Unit,
+) {
+    val googleTileProvider = remember(tileProvider) {
+        GoogleTileProvider { x, y, zoom ->
+            tileProvider.getTile(x, y, zoom)?.googleTile ?: GoogleTileProvider.NO_TILE
+        }
+    }
+
+    AndroidTileOverlay(
+        tileProvider = googleTileProvider,
+        state = state.androidState,
+        fadeIn = fadeIn,
+        transparency = transparency,
+        visible = visible,
+        zIndex = zIndex,
+        onClick = { onClick(it) },
+    )
+}

--- a/kmp-maps-compose/src/commonMain/kotlin/eu/buney/maps/NativeTileOverlay.kt
+++ b/kmp-maps-compose/src/commonMain/kotlin/eu/buney/maps/NativeTileOverlay.kt
@@ -1,0 +1,10 @@
+package eu.buney.maps
+
+/**
+ * Platform-specific tile overlay type.
+ *
+ * On Android, this is [com.google.android.gms.maps.model.TileOverlay].
+ * On iOS, this is [Nothing] because [GMSTileLayer] does not support tap events,
+ * so the [TileOverlay] onClick callback never fires.
+ */
+expect class NativeTileOverlay

--- a/kmp-maps-compose/src/commonMain/kotlin/eu/buney/maps/TileOverlay.kt
+++ b/kmp-maps-compose/src/commonMain/kotlin/eu/buney/maps/TileOverlay.kt
@@ -1,0 +1,105 @@
+package eu.buney.maps
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+
+/**
+ * Provides tile images for a [TileOverlay].
+ *
+ * Implementations must be thread-safe as [getTile] may be called from
+ * background threads on both platforms.
+ */
+interface TileProvider {
+    /**
+     * Returns a [Tile] for the given tile coordinates, or null if no tile
+     * is available at this location.
+     *
+     * @param x The x coordinate of the tile (column).
+     * @param y The y coordinate of the tile (row).
+     * @param zoom The zoom level.
+     * @return A [Tile] containing encoded image data, or null for no tile.
+     */
+    fun getTile(x: Int, y: Int, zoom: Int): Tile?
+}
+
+/**
+ * Represents a single map tile backed by a platform-native image type.
+ *
+ * On Android, wraps a `com.google.android.gms.maps.model.Tile` (encoded bytes).
+ * On iOS, wraps a `UIImage` — enabling zero-copy when tiles are created from raw pixels.
+ *
+ * Use [TileFactory] to create instances.
+ */
+expect class Tile
+
+/**
+ * Factory for creating [Tile] instances from pixel data or encoded images.
+ */
+expect object TileFactory {
+    /**
+     * Creates a [Tile] from raw ARGB pixel bytes.
+     *
+     * @param bytes Raw pixel data — 4 bytes per pixel: alpha, red, green, blue.
+     *              The array size must be exactly `width * height * 4`.
+     * @param width The width of the tile in pixels.
+     * @param height The height of the tile in pixels.
+     */
+    fun fromBytes(bytes: ByteArray, width: Int, height: Int): Tile
+
+    /**
+     * Creates a [Tile] from an already-encoded image (PNG, JPEG, etc.).
+     *
+     * @param data The encoded image data.
+     * @param width The width of the tile in pixels.
+     * @param height The height of the tile in pixels.
+     */
+    fun fromEncodedImage(data: ByteArray, width: Int, height: Int): Tile
+}
+
+/**
+ * A state object that can be hoisted to control the state of a [TileOverlay].
+ * A [TileOverlayState] may only be used by a single [TileOverlay] composable at a time.
+ */
+@Stable
+expect class TileOverlayState() {
+    /**
+     * Clears the tile cache so that all tiles will be requested again from the [TileProvider].
+     *
+     * Call this when the tiles provided by the [TileProvider] become stale
+     * and need to be refreshed.
+     */
+    fun clearTileCache()
+}
+
+/**
+ * Creates and remembers a [TileOverlayState].
+ */
+@Composable
+fun rememberTileOverlayState(): TileOverlayState {
+    return remember { TileOverlayState() }
+}
+
+/**
+ * A composable that adds a tile overlay to the map.
+ *
+ * @param tileProvider The [TileProvider] to use for this tile overlay.
+ * @param state The [TileOverlayState] to control this overlay (e.g., cache clearing).
+ * @param fadeIn Whether the tiles should fade in. Default is true.
+ * @param transparency The transparency of the tile overlay (0 = opaque, 1 = transparent).
+ * @param visible Whether the tile overlay is visible. Default is true.
+ * @param zIndex The z-index of the tile overlay. Default is 0f.
+ * @param onClick A callback invoked when the tile overlay is clicked.
+ *   Note: This only fires on Android. iOS GMSTileLayer does not support tap events.
+ */
+@Composable
+@GoogleMapComposable
+expect fun TileOverlay(
+    tileProvider: TileProvider,
+    state: TileOverlayState = rememberTileOverlayState(),
+    fadeIn: Boolean = true,
+    transparency: Float = 0f,
+    visible: Boolean = true,
+    zIndex: Float = 0f,
+    onClick: (NativeTileOverlay) -> Unit = {},
+)

--- a/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/BitmapDescriptor.ios.kt
+++ b/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/BitmapDescriptor.ios.kt
@@ -1,17 +1,5 @@
 package eu.buney.maps
 
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.usePinned
-import platform.CoreGraphics.CGBitmapContextCreate
-import platform.CoreGraphics.CGBitmapContextCreateImage
-import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
-import platform.CoreGraphics.CGColorSpaceRelease
-import platform.CoreGraphics.CGContextRelease
-import platform.CoreGraphics.CGImageAlphaInfo
-import platform.CoreGraphics.kCGBitmapByteOrder32Big
-import platform.Foundation.NSData
-import platform.Foundation.create
 import platform.UIKit.UIImage
 
 /**
@@ -25,51 +13,13 @@ actual class BitmapDescriptor(
 /**
  * iOS implementation of [BitmapDescriptorFactory].
  */
-@OptIn(ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
 actual object BitmapDescriptorFactory {
 
     actual fun fromBytes(bytes: ByteArray, width: Int, height: Int): BitmapDescriptor {
-        require(bytes.size == width * height * 4) {
-            "Byte array size (${bytes.size}) must equal width * height * 4 (${width * height * 4})"
-        }
-
-        val colorSpace = CGColorSpaceCreateDeviceRGB()
-            ?: error("Failed to create color space")
-
-        try {
-            val bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedFirst.value or kCGBitmapByteOrder32Big
-            val bytesPerRow = width * 4
-
-            val context = bytes.usePinned { pinned ->
-                CGBitmapContextCreate(
-                    data = pinned.addressOf(0),
-                    width = width.toULong(),
-                    height = height.toULong(),
-                    bitsPerComponent = 8u,
-                    bytesPerRow = bytesPerRow.toULong(),
-                    space = colorSpace,
-                    bitmapInfo = bitmapInfo
-                )
-            } ?: error("Failed to create bitmap context")
-
-            try {
-                val cgImage = CGBitmapContextCreateImage(context)
-                    ?: error("Failed to create CGImage from context")
-                val uiImage = UIImage(cGImage = cgImage)
-                return BitmapDescriptor(uiImage)
-            } finally {
-                CGContextRelease(context)
-            }
-        } finally {
-            CGColorSpaceRelease(colorSpace)
-        }
+        return BitmapDescriptor(argbBytesToUIImage(bytes, width, height))
     }
 
     actual fun fromEncodedImage(data: ByteArray): BitmapDescriptor {
-        val nsData = data.usePinned { pinned ->
-            NSData.create(bytes = pinned.addressOf(0), length = data.size.toULong())
-        }
-        val uiImage = UIImage(data = nsData)
-        return BitmapDescriptor(uiImage)
+        return BitmapDescriptor(encodedBytesToUIImage(data))
     }
 }

--- a/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/ImageConversions.ios.kt
+++ b/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/ImageConversions.ios.kt
@@ -1,0 +1,93 @@
+package eu.buney.maps
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.CoreGraphics.CGColorRenderingIntent
+import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
+import platform.CoreGraphics.CGColorSpaceRelease
+import platform.CoreGraphics.CGDataProviderCreateWithData
+import platform.CoreGraphics.CGDataProviderRelease
+import platform.CoreGraphics.CGImageAlphaInfo
+import platform.CoreGraphics.CGImageCreate
+import platform.CoreGraphics.CGImageRelease
+import platform.CoreGraphics.kCGBitmapByteOrder32Big
+import platform.Foundation.NSData
+import platform.Foundation.create
+import platform.UIKit.UIImage
+
+/**
+ * Converts raw ARGB pixel bytes into a [UIImage].
+ *
+ * Uses kCGImageAlphaFirst (non-premultiplied ARGB), which CGImageCreate
+ * supports directly — no pixel premultiplication needed.
+ *
+ * @param bytes Raw pixel data — 4 bytes per pixel: alpha, red, green, blue.
+ * @param width Image width in pixels.
+ * @param height Image height in pixels.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal fun argbBytesToUIImage(bytes: ByteArray, width: Int, height: Int): UIImage {
+    require(bytes.size == width * height * 4) {
+        "Byte array size (${bytes.size}) must equal width * height * 4 (${width * height * 4})"
+    }
+
+    val colorSpace = CGColorSpaceCreateDeviceRGB()
+        ?: error("Failed to create color space")
+
+    try {
+        val bitmapInfo =
+            CGImageAlphaInfo.kCGImageAlphaFirst.value or kCGBitmapByteOrder32Big
+        val bytesPerRow = (width * 4).toULong()
+        val bufferSize = bytes.size.toULong()
+
+        val dataProvider = bytes.usePinned { pinned ->
+            CGDataProviderCreateWithData(
+                info = null,
+                data = pinned.addressOf(0),
+                size = bufferSize,
+                releaseData = null,
+            )
+        } ?: error("Failed to create data provider")
+
+        try {
+            val cgImage = CGImageCreate(
+                width = width.toULong(),
+                height = height.toULong(),
+                bitsPerComponent = 8u,
+                bitsPerPixel = 32u,
+                bytesPerRow = bytesPerRow,
+                space = colorSpace,
+                bitmapInfo = bitmapInfo,
+                provider = dataProvider,
+                decode = null,
+                shouldInterpolate = false,
+                intent = CGColorRenderingIntent.kCGRenderingIntentDefault,
+            ) ?: error("Failed to create CGImage from data provider")
+
+            try {
+                return UIImage(cGImage = cgImage)
+            } finally {
+                CGImageRelease(cgImage)
+            }
+        } finally {
+            CGDataProviderRelease(dataProvider)
+        }
+    } finally {
+        CGColorSpaceRelease(colorSpace)
+    }
+}
+
+/**
+ * Decodes encoded image bytes (PNG, JPEG, etc.) into a [UIImage].
+ *
+ * @param data Encoded image data.
+ */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+internal fun encodedBytesToUIImage(data: ByteArray): UIImage {
+    val nsData = data.usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = data.size.toULong())
+    }
+    return UIImage(data = nsData)
+}

--- a/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/NativeTileOverlay.ios.kt
+++ b/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/NativeTileOverlay.ios.kt
@@ -1,0 +1,5 @@
+package eu.buney.maps
+
+// Placeholder — iOS GMSTileLayer doesn't support tap events,
+// so the TileOverlay onClick callback is never invoked on iOS.
+actual class NativeTileOverlay internal constructor()

--- a/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/TileOverlay.ios.kt
+++ b/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/TileOverlay.ios.kt
@@ -1,0 +1,118 @@
+package eu.buney.maps
+
+import GoogleMaps.GMSSyncTileLayer
+import GoogleMaps.GMSTileLayer
+import GoogleMaps.kGMSTileLayerNoTile
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposeNode
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.currentComposer
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.UIKit.UIImage
+import platform.UIKit.UIScreen
+
+/**
+ * iOS implementation of [Tile].
+ * Wraps a [UIImage] — avoids encode/decode roundtrips for raw pixel tiles.
+ */
+actual class Tile(val uiImage: UIImage)
+
+/**
+ * iOS implementation of [TileFactory].
+ */
+actual object TileFactory {
+    actual fun fromBytes(bytes: ByteArray, width: Int, height: Int): Tile {
+        return Tile(argbBytesToUIImage(bytes, width, height))
+    }
+
+    actual fun fromEncodedImage(data: ByteArray, width: Int, height: Int): Tile {
+        return Tile(encodedBytesToUIImage(data))
+    }
+}
+
+/**
+ * iOS implementation of [TileOverlayState].
+ * Holds a reference to the [GMSTileLayer] for cache clearing.
+ */
+@OptIn(ExperimentalForeignApi::class)
+@Stable
+actual class TileOverlayState actual constructor() {
+    internal var tileLayer: GMSTileLayer? = null
+
+    actual fun clearTileCache() {
+        (tileLayer ?: error("This TileOverlayState is not associated with a TileOverlay"))
+            .clearTileCache()
+    }
+}
+
+/**
+ * A [GMSSyncTileLayer] subclass that bridges the cross-platform [TileProvider]
+ * to the iOS Google Maps SDK.
+ *
+ * [GMSSyncTileLayer.tileForX] is called on background threads by the SDK,
+ * matching our [TileProvider.getTile] contract.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal class KmpTileLayer(
+    var tileProvider: TileProvider,
+) : GMSSyncTileLayer() {
+
+    override fun tileForX(x: ULong, y: ULong, zoom: ULong): UIImage {
+        val tile = tileProvider.getTile(x.toInt(), y.toInt(), zoom.toInt())
+            ?: return kGMSTileLayerNoTile
+        return tile.uiImage
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+@GoogleMapComposable
+actual fun TileOverlay(
+    tileProvider: TileProvider,
+    state: TileOverlayState,
+    fadeIn: Boolean,
+    transparency: Float,
+    visible: Boolean,
+    zIndex: Float,
+    onClick: (NativeTileOverlay) -> Unit,
+) {
+    val mapApplier = currentComposer.applier as? MapApplier
+        ?: error("TileOverlay must be used within a GoogleMap composable")
+
+    ComposeNode<TileOverlayNode, MapApplier>(
+        factory = {
+            val tileLayer = KmpTileLayer(tileProvider).apply {
+                // iOS tileSize is in pixels, Android renders tiles at 256dp;
+                // scale by screen density for consistency
+                this.tileSize = (256.0 * UIScreen.mainScreen.scale).toLong()
+                this.fadeIn = fadeIn
+                this.opacity = 1f - transparency
+                this.zIndex = zIndex.toInt()
+                this.map = if (visible) mapApplier.mapView else null
+            }
+
+            state.tileLayer = tileLayer
+
+            TileOverlayNode(
+                tileLayer = tileLayer,
+                tileOverlayState = state,
+            )
+        },
+        update = {
+            update(tileProvider) {
+                this.tileLayer.tileProvider = it
+                this.tileLayer.clearTileCache()
+            }
+            update(fadeIn) { this.tileLayer.fadeIn = it }
+            update(transparency) { this.tileLayer.opacity = 1f - it }
+            update(zIndex) { this.tileLayer.zIndex = it.toInt() }
+            update(visible) {
+                this.tileLayer.map = if (it) mapApplier.mapView else null
+            }
+            update(state) {
+                this.tileOverlayState = it
+                it.tileLayer = this.tileLayer
+            }
+        }
+    )
+}

--- a/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/TileOverlayNode.kt
+++ b/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/TileOverlayNode.kt
@@ -1,0 +1,30 @@
+package eu.buney.maps
+
+import kotlinx.cinterop.ExperimentalForeignApi
+
+/**
+ * [MapNode] implementation for tile overlays.
+ *
+ * Holds the [KmpTileLayer] and manages its lifecycle. Unlike other overlay nodes,
+ * there is no click callback because tile layers are not [GMSOverlay] subclasses and
+ * do not receive tap events.
+ *
+ * @param tileLayer The underlying [KmpTileLayer].
+ * @param tileOverlayState The [TileOverlayState] associated with this overlay.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal class TileOverlayNode(
+    val tileLayer: KmpTileLayer,
+    var tileOverlayState: TileOverlayState,
+) : MapNode {
+
+    override fun onRemoved() {
+        tileLayer.map = null
+        tileOverlayState.tileLayer = null
+    }
+
+    override fun onCleared() {
+        tileLayer.map = null
+        tileOverlayState.tileLayer = null
+    }
+}

--- a/sample/shared/src/commonMain/kotlin/eu/buney/sample/App.kt
+++ b/sample/shared/src/commonMain/kotlin/eu/buney/sample/App.kt
@@ -63,6 +63,7 @@ fun App() {
                 DemoScreen.BasicMap -> MapScreen(modifier = contentModifier)
                 DemoScreen.MarkerClustering -> ClusteringScreen(modifier = contentModifier)
                 DemoScreen.StyledMap -> StyledMapScreen(modifier = contentModifier)
+                DemoScreen.TileOverlay -> TileOverlayScreen(modifier = contentModifier)
             }
         }
     }

--- a/sample/shared/src/commonMain/kotlin/eu/buney/sample/ClusteringScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/eu/buney/sample/ClusteringScreen.kt
@@ -37,6 +37,7 @@ import eu.buney.maps.LatLng
 import eu.buney.maps.utils.clustering.Cluster
 import eu.buney.maps.utils.clustering.ClusterItem
 import eu.buney.maps.utils.clustering.Clustering
+import eu.buney.maps.Circle
 import eu.buney.maps.rememberCameraPositionState
 import eu.buney.maps.MarkerInfoWindow
 import eu.buney.maps.rememberUpdatedMarkerState
@@ -52,6 +53,7 @@ private val singapore = LatLng(1.35, 103.87)
 private enum class ClusteringType {
     Default,
     CustomUi,
+    Decorations,
 }
 
 data class MyItem(
@@ -91,6 +93,7 @@ fun ClusteringScreen(modifier: Modifier = Modifier) {
                 when (clusteringType) {
                     ClusteringType.Default -> DefaultClustering(items)
                     ClusteringType.CustomUi -> CustomUiClustering(items)
+                    ClusteringType.Decorations -> DecorationsClustering(items)
                 }
 
                 // Standalone marker outside the clustering system
@@ -165,6 +168,22 @@ private fun CustomUiClustering(items: List<MyItem>) {
 }
 
 @Composable
+private fun DecorationsClustering(items: List<MyItem>) {
+    Clustering(
+        items = items,
+        clusterItemDecoration = { _, position ->
+            Circle(
+                center = position,
+                radius = 10000.0,
+                fillColor = Color.Blue.copy(alpha = 0.2f),
+                strokeColor = Color.Blue,
+                strokeWidth = 2f,
+            )
+        },
+    )
+}
+
+@Composable
 private fun CircleContent(
     color: Color,
     text: String,
@@ -221,6 +240,7 @@ private fun ClusteringTypeControls(
                     text = when (type) {
                         ClusteringType.Default -> "Default"
                         ClusteringType.CustomUi -> "Custom UI"
+                        ClusteringType.Decorations -> "Decorations"
                     },
                 )
             }

--- a/sample/shared/src/commonMain/kotlin/eu/buney/sample/DemoList.kt
+++ b/sample/shared/src/commonMain/kotlin/eu/buney/sample/DemoList.kt
@@ -60,8 +60,13 @@ val allDemoGroups = listOf(
         title = "Maps",
         demos = listOf(
             DemoScreen.BasicMap,
-            DemoScreen.MarkerClustering,
             DemoScreen.StyledMap,
+        ),
+    ),
+    DemoGroup(
+        title = "Markers",
+        demos = listOf(
+            DemoScreen.MarkerClustering,
         ),
     ),
 )

--- a/sample/shared/src/commonMain/kotlin/eu/buney/sample/DemoList.kt
+++ b/sample/shared/src/commonMain/kotlin/eu/buney/sample/DemoList.kt
@@ -42,6 +42,10 @@ enum class DemoScreen(val title: String, val description: String) {
         title = "Styled Map",
         description = "Custom map styling via JSON",
     ),
+    TileOverlay(
+        title = "Tile Overlay",
+        description = "Custom tile overlay with cache management",
+    ),
 }
 
 /**
@@ -61,6 +65,12 @@ val allDemoGroups = listOf(
         demos = listOf(
             DemoScreen.BasicMap,
             DemoScreen.StyledMap,
+        ),
+    ),
+    DemoGroup(
+        title = "Map Features",
+        demos = listOf(
+            DemoScreen.TileOverlay,
         ),
     ),
     DemoGroup(

--- a/sample/shared/src/commonMain/kotlin/eu/buney/sample/TileOverlayScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/eu/buney/sample/TileOverlayScreen.kt
@@ -1,0 +1,107 @@
+package eu.buney.sample
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import eu.buney.maps.CameraPosition
+import eu.buney.maps.GoogleMap
+import eu.buney.maps.LatLng
+import eu.buney.maps.TileFactory
+import eu.buney.maps.TileOverlay
+import eu.buney.maps.TileProvider
+import eu.buney.maps.rememberCameraPositionState
+import eu.buney.maps.rememberTileOverlayState
+
+private val sanFrancisco = LatLng(37.7749, -122.4194)
+
+@Composable
+fun TileOverlayScreen(modifier: Modifier = Modifier) {
+    var tileVersion by remember { mutableIntStateOf(0) }
+    val state = rememberTileOverlayState()
+
+    val tileProvider = remember(tileVersion) {
+        object : TileProvider {
+            override fun getTile(x: Int, y: Int, zoom: Int) = createColoredTile(
+                tileSize = 256,
+                r = ((x * 37 + tileVersion * 60) % 256),
+                g = ((y * 73 + tileVersion * 90) % 256),
+                b = ((zoom * 51 + tileVersion * 120) % 256),
+                a = 100,
+            )
+        }
+    }
+
+    Box(modifier = modifier) {
+        GoogleMap(
+            modifier = Modifier.fillMaxSize(),
+            cameraPositionState = rememberCameraPositionState {
+                position = CameraPosition(target = sanFrancisco, zoom = 12f)
+            },
+        ) {
+            TileOverlay(
+                tileProvider = tileProvider,
+                state = state,
+                transparency = 0f,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+        ) {
+            Button(onClick = { state.clearTileCache() }) {
+                Text("Clear Cache")
+            }
+            Button(
+                onClick = { tileVersion++ },
+                modifier = Modifier.padding(top = 8.dp),
+            ) {
+                Text("New Colors")
+            }
+        }
+    }
+}
+
+/**
+ * Creates a solid-color tile from raw ARGB pixels using platform-native encoding.
+ */
+private fun createColoredTile(tileSize: Int, r: Int, g: Int, b: Int, a: Int) =
+    TileFactory.fromBytes(
+        bytes = createSolidArgbPixels(tileSize, tileSize, a, r, g, b),
+        width = tileSize,
+        height = tileSize,
+    )
+
+/**
+ * Builds a raw ARGB pixel buffer for a solid-color rectangle.
+ * Format: 4 bytes per pixel — alpha, red, green, blue.
+ */
+private fun createSolidArgbPixels(
+    width: Int,
+    height: Int,
+    a: Int,
+    r: Int,
+    g: Int,
+    b: Int,
+): ByteArray {
+    val pixels = ByteArray(width * height * 4)
+    for (i in pixels.indices step 4) {
+        pixels[i] = a.toByte()
+        pixels[i + 1] = r.toByte()
+        pixels[i + 2] = g.toByte()
+        pixels[i + 3] = b.toByte()
+    }
+    return pixels
+}


### PR DESCRIPTION
### Features

- **`TileOverlay` composable** — Cross-platform tile overlay support wrapping `TileProvider`/`TileOverlay` on Android and `GMSSyncTileLayer` on iOS. Includes `TileOverlayState` for cache management, with fadeIn, transparency, visibility, and zIndex properties. (closes #2)
- **`clusterItemDecoration`** — New parameter on all `Clustering` overloads for rendering additional map content (circles, polylines, etc.) alongside each unclustered item, matching [android-maps-compose#848](https://github.com/googlemaps/android-maps-compose/pull/848)

### Breaking Changes

- **`clusterItemDecoration` signature** — Changed from `(T) -> Unit` to `(T, LatLng) -> Unit` so decorations receive the animated position during cluster transitions

### Other Changes

- Updated maps-compose to 8.2.0, Compose Multiplatform to 1.10.2, AGP to 9.1.0