### PR TITLE
Fix newLatLngBounds padding interpretation on iOS

### DIFF
--- a/kmp-maps-compose/src/commonMain/kotlin/eu/buney/maps/CameraUpdate.kt
+++ b/kmp-maps-compose/src/commonMain/kotlin/eu/buney/maps/CameraUpdate.kt
@@ -52,7 +52,8 @@ object CameraUpdateFactory {
      * Creates a [CameraUpdate] that moves the camera to fit the specified bounds.
      *
      * @param bounds The bounds to fit within the viewport.
-     * @param padding Padding in pixels to apply around the bounds.
+     * @param padding Padding in physical pixels to apply around the bounds
+     * (converted to points on iOS).
      * @return A [CameraUpdate] representing the camera movement.
      */
     fun newLatLngBounds(bounds: LatLngBounds, padding: Int): CameraUpdate =

--- a/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/CameraPositionState.ios.kt
+++ b/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/CameraPositionState.ios.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CancellationException
@@ -16,7 +17,9 @@ import platform.CoreLocation.CLLocationCoordinate2DMake
 import platform.QuartzCore.CATransaction
 import platform.QuartzCore.CATransaction.Companion.setAnimationDuration
 import platform.QuartzCore.CATransaction.Companion.setCompletionBlock
+import platform.UIKit.UIEdgeInsets
 import platform.UIKit.UIEdgeInsetsMake
+import platform.UIKit.UIScreen
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -211,8 +214,7 @@ private suspend fun GMSMapView.applyAnimatedCameraUpdate(
                 }
                 is CameraUpdate.NewLatLngBounds -> {
                     val gmsBounds = update.bounds.toGMSCoordinateBounds()
-                    val padding = update.padding.toDouble()
-                    val insets = UIEdgeInsetsMake(padding, padding, padding, padding)
+                    val insets = boundsPaddingInsets(update.padding)
                     val cameraPosition = cameraForBounds(gmsBounds, insets = insets)
                     if (cameraPosition != null) {
                         animateToCameraPosition(cameraPosition)
@@ -247,8 +249,7 @@ private fun GMSMapView.applyInstantCameraUpdate(update: CameraUpdate): CameraPos
         }
         is CameraUpdate.NewLatLngBounds -> {
             val gmsBounds = update.bounds.toGMSCoordinateBounds()
-            val padding = update.padding.toDouble()
-            val insets = UIEdgeInsetsMake(padding, padding, padding, padding)
+            val insets = boundsPaddingInsets(update.padding)
             val gmsPosition = cameraForBounds(gmsBounds, insets = insets)
             if (gmsPosition != null) {
                 camera = gmsPosition
@@ -266,6 +267,18 @@ private fun GMSMapView.applyInstantCameraUpdate(update: CameraUpdate): CameraPos
             }
         }
     }
+}
+
+/**
+ * Converts [CameraUpdate.NewLatLngBounds.padding] (physical pixels, per the Android SDK
+ * convention) to per-edge insets in points, as expected by `cameraForBounds:insets:`.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun GMSMapView.boundsPaddingInsets(paddingPx: Int): CValue<UIEdgeInsets> {
+    val scale = traitCollection.displayScale.takeIf { it > 0.0 }
+        ?: UIScreen.mainScreen.scale
+    val padding = paddingPx / scale
+    return UIEdgeInsetsMake(padding, padding, padding, padding)
 }
 
 // endregion


### PR DESCRIPTION
Fixes #12

`CameraUpdateFactory.newLatLngBounds` documents padding in physical pixels
(Android SDK convention), but the iOS implementation passed the value unscaled
to `cameraForBounds:insets:`, which expects points. On 2–3× displays the
padding was inflated accordingly, and once the insets exceeded the viewport the
SDK silently fell back to minimum zoom. The padding is now converted to points
via the view's display scale.

Verified with the sample app's "Fit All" (NYC landmark bounds) at `padding = 220`
on a Pixel 9a emulator and an iPhone 16 Pro simulator:

| | Before | After |
|---|---|---|
| **iOS** | <img src="https://raw.githubusercontent.com/yankeppey/kmp-maps-compose/60f16a9f5309067f6d252e7f638ce074d2c7f21c/ios-1-before-fix.png" width="260"> | <img src="https://raw.githubusercontent.com/yankeppey/kmp-maps-compose/60f16a9f5309067f6d252e7f638ce074d2c7f21c/ios-2-after-fix.png" width="260"> |
| **Android** (unchanged) | <img src="https://raw.githubusercontent.com/yankeppey/kmp-maps-compose/60f16a9f5309067f6d252e7f638ce074d2c7f21c/android-1-before-fix.png" width="260"> | <img src="https://raw.githubusercontent.com/yankeppey/kmp-maps-compose/60f16a9f5309067f6d252e7f638ce074d2c7f21c/android-2-after-fix.png" width="260"> |