### PR TITLE
0.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, dev ]
   workflow_dispatch:
     inputs:
       publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.1
+
+Based on [android-maps-compose 8.3.0](https://github.com/googlemaps/android-maps-compose).
+
+**SDK Versions:**
+- Google Maps iOS SDK: 10.8.0
+- Google Play Services Maps: 20.0.0
+
+### Bug Fixes
+
+- **iOS: Fix `newLatLngBounds` padding interpretation** - `CameraUpdateFactory.newLatLngBounds` takes padding in physical pixels (Android SDK convention), but on iOS the value was passed unscaled to `cameraForBounds:insets:`, which expects points. On 2-3x displays the effective padding was inflated by the screen scale, and when the insets exceeded the viewport the SDK silently fell back to minimum zoom, showing the whole world. The padding is now converted via the view's display scale, so the same value produces the same visual result on both platforms. If you previously worked around this by pre-dividing the padding on iOS, remove the workaround (#12)
+
 ## 0.6.0
 
 Based on [android-maps-compose 8.3.0](https://github.com/googlemaps/android-maps-compose).

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Add the dependency to your `build.gradle.kts`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("eu.buney.maps:kmp-maps-compose:0.6.0")
+            implementation("eu.buney.maps:kmp-maps-compose:0.6.1")
 
             // Optional: clustering utilities
-            implementation("eu.buney.maps:kmp-maps-compose-utils:0.6.0")
+            implementation("eu.buney.maps:kmp-maps-compose-utils:0.6.1")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmp-maps-compose = "0.6.0"
+kmp-maps-compose = "0.6.1-SNAPSHOT"
 kotlin = "2.3.20"
 compose = "1.10.3"
 agp = "9.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmp-maps-compose = "0.6.1-SNAPSHOT"
+kmp-maps-compose = "0.6.1"
 kotlin = "2.3.20"
 compose = "1.10.3"
 agp = "9.1.0"

--- a/kmp-maps-compose/src/commonMain/kotlin/eu/buney/maps/CameraUpdate.kt
+++ b/kmp-maps-compose/src/commonMain/kotlin/eu/buney/maps/CameraUpdate.kt
@@ -52,7 +52,8 @@ object CameraUpdateFactory {
      * Creates a [CameraUpdate] that moves the camera to fit the specified bounds.
      *
      * @param bounds The bounds to fit within the viewport.
-     * @param padding Padding in pixels to apply around the bounds.
+     * @param padding Padding in physical pixels to apply around the bounds
+     * (converted to points on iOS).
      * @return A [CameraUpdate] representing the camera movement.
      */
     fun newLatLngBounds(bounds: LatLngBounds, padding: Int): CameraUpdate =

--- a/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/CameraPositionState.ios.kt
+++ b/kmp-maps-compose/src/iosMain/kotlin/eu/buney/maps/CameraPositionState.ios.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CancellationException
@@ -16,7 +17,9 @@ import platform.CoreLocation.CLLocationCoordinate2DMake
 import platform.QuartzCore.CATransaction
 import platform.QuartzCore.CATransaction.Companion.setAnimationDuration
 import platform.QuartzCore.CATransaction.Companion.setCompletionBlock
+import platform.UIKit.UIEdgeInsets
 import platform.UIKit.UIEdgeInsetsMake
+import platform.UIKit.UIScreen
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -211,8 +214,7 @@ private suspend fun GMSMapView.applyAnimatedCameraUpdate(
                 }
                 is CameraUpdate.NewLatLngBounds -> {
                     val gmsBounds = update.bounds.toGMSCoordinateBounds()
-                    val padding = update.padding.toDouble()
-                    val insets = UIEdgeInsetsMake(padding, padding, padding, padding)
+                    val insets = boundsPaddingInsets(update.padding)
                     val cameraPosition = cameraForBounds(gmsBounds, insets = insets)
                     if (cameraPosition != null) {
                         animateToCameraPosition(cameraPosition)
@@ -247,8 +249,7 @@ private fun GMSMapView.applyInstantCameraUpdate(update: CameraUpdate): CameraPos
         }
         is CameraUpdate.NewLatLngBounds -> {
             val gmsBounds = update.bounds.toGMSCoordinateBounds()
-            val padding = update.padding.toDouble()
-            val insets = UIEdgeInsetsMake(padding, padding, padding, padding)
+            val insets = boundsPaddingInsets(update.padding)
             val gmsPosition = cameraForBounds(gmsBounds, insets = insets)
             if (gmsPosition != null) {
                 camera = gmsPosition
@@ -266,6 +267,18 @@ private fun GMSMapView.applyInstantCameraUpdate(update: CameraUpdate): CameraPos
             }
         }
     }
+}
+
+/**
+ * Converts [CameraUpdate.NewLatLngBounds.padding] (physical pixels, per the Android SDK
+ * convention) to per-edge insets in points, as expected by `cameraForBounds:insets:`.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun GMSMapView.boundsPaddingInsets(paddingPx: Int): CValue<UIEdgeInsets> {
+    val scale = traitCollection.displayScale.takeIf { it > 0.0 }
+        ?: UIScreen.mainScreen.scale
+    val padding = paddingPx / scale
+    return UIEdgeInsetsMake(padding, padding, padding, padding)
 }
 
 // endregion


### PR DESCRIPTION
### Bug Fixes

- **iOS: Fix `newLatLngBounds` padding interpretation** — `CameraUpdateFactory.newLatLngBounds` takes padding in physical pixels (Android SDK convention), but on iOS the value was passed unscaled to `cameraForBounds:insets:`, which expects points. On 2-3x displays the effective padding was inflated by the screen scale, and when the insets exceeded the viewport the SDK silently fell back to minimum zoom, showing the whole world. The padding is now converted via the view's display scale, so the same value produces the same visual result on both platforms. If you previously worked around this by pre-dividing the padding on iOS, remove the workaround (fixes #12)