### PR TITLE
feat(clustering): support cached marker icons and visibility filtering

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kmp-maps-compose = "0.6.1"
 kotlin = "2.3.20"
 compose = "1.10.3"
-agp = "9.1.0"
+agp = "9.2.1"
 maps-compose = "8.3.0"
 # play-services-maps version should match maps-compose transitive dependency:
 # maps-compose 8.3.0 -> maps-ktx 6.0.1 -> play-services-maps 20.0.0
@@ -12,7 +12,7 @@ activity-compose = "1.13.0"
 androidx-core = "1.18.0"
 kermit = "2.1.0"
 buildkonfig = "0.18.0"
-spmForKmp = "1.7.0"
+spmForKmp = "1.9.1"
 vanniktechMavenPublish = "0.36.0"
 
 [libraries]

--- a/kmp-maps-compose-utils/README.md
+++ b/kmp-maps-compose-utils/README.md
@@ -9,6 +9,55 @@ Clustering support is provided as its own Compose-first common Kotlin port, not 
 - there are a number of small API and behavioral differences between the two that might make it confusing if the Kotlin code is the same
 - wrapping and unwrapping the common types into native types has a comparable cost
 
+For unclustered items backed by cached `BitmapDescriptor`s, use `clusterItemIcon` instead of
+`clusterItemContent`. The item markers remain part of the same clustering and split/merge
+transition pipeline, but do not create Compose-rendered marker bitmaps:
+
+```kotlin
+Clustering(
+    items = vehicles,
+    clusterItemIcon = { vehicle -> vehicleMarkerIcons.iconFor(vehicle) },
+    clusterItemAnchor = Offset(0.5f, 0.5f),
+)
+```
+
+`clusterItemIcon` takes precedence over `clusterItemContent` when both are provided.
+
+`clusterItemAnchor` controls which point of the icon is placed at the item's coordinate. The
+default is `Offset(0.5f, 1f)`, which suits pin-shaped markers. Use `Offset(0.5f, 0.5f)` for
+vehicle or other centre-aligned icons.
+
+### Compose item content keys
+
+When using `clusterItemContent`, use `clusterItemContentKey` to specify when the generated marker
+bitmap should be rebuilt. Return only values that affect the marker's appearance:
+
+```kotlin
+Clustering(
+    items = vehicles,
+    clusterItemContentKey = { vehicle -> vehicle.status },
+    clusterItemContent = { vehicle ->
+        VehicleMarkerContent(status = vehicle.status)
+    },
+)
+```
+
+When `clusterItemContentKey` is omitted, the item itself is used as the key.
+
+### Marker visibility
+
+Use `markerVisibility` to suppress marker output outside a visible area. This affects rendering
+only: all items still participate in cluster calculation and split/merge transitions.
+
+```kotlin
+Clustering(
+    items = vehicles,
+    markerVisibility = { position ->
+        cameraPositionState.projection?.contains(position) ?: true
+    },
+)
+```
+
 ### Known limitations
 
 Caching and performance have not really been battle-tested and there is definitely room for improvement in the future:

--- a/kmp-maps-compose-utils/src/commonMain/kotlin/eu/buney/maps/utils/clustering/Clustering.kt
+++ b/kmp-maps-compose-utils/src/commonMain/kotlin/eu/buney/maps/utils/clustering/Clustering.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.geometry.Offset
+import eu.buney.maps.BitmapDescriptor
 import eu.buney.maps.GoogleMapComposable
 import eu.buney.maps.LatLng
 import eu.buney.maps.Marker
@@ -31,6 +33,14 @@ import eu.buney.maps.rememberUpdatedMarkerState
  *
  * Clusters animate when splitting (zoom in: one cluster marker explodes into individual
  * markers) and merging (zoom out: individual markers collapse into a cluster marker).
+ *
+ * When [clusterItemIcon] is supplied, unclustered items are rendered with a regular [Marker]
+ * using that descriptor and [clusterItemAnchor]. This takes precedence over [clusterItemContent]
+ * and avoids creating a Compose bitmap for every item. The callback should return a cached
+ * descriptor rather than creating one during rendering.
+ *
+ * [markerVisibility] only controls marker output. All [items] still participate in cluster
+ * calculation and transitions, so hiding offscreen markers does not change cluster membership.
  */
 @Composable
 fun <T : ClusterItem> Clustering(
@@ -40,6 +50,10 @@ fun <T : ClusterItem> Clustering(
     exitAnimationSpec: FiniteAnimationSpec<Float> = DefaultAnimationSpec,
     clusterContent: (@Composable (Cluster<T>) -> Unit)? = null,
     clusterItemContent: (@Composable (T) -> Unit)? = null,
+    clusterItemContentKey: ((T) -> Any)? = null,
+    clusterItemIcon: ((T) -> BitmapDescriptor?)? = null,
+    clusterItemAnchor: Offset = Offset(0.5f, 1.0f),
+    markerVisibility: ((LatLng) -> Boolean)? = null,
     clusterItemDecoration: @Composable @GoogleMapComposable (T, LatLng) -> Unit = { _, _ -> },
 ) {
     val cameraPositionState = currentCameraPositionState
@@ -89,57 +103,83 @@ fun <T : ClusterItem> Clustering(
         enterAnimationSpec = enterAnimationSpec,
         exitAnimationSpec = exitAnimationSpec,
         clusterContent = { cluster, _, _, position ->
-            val content: @Composable (Cluster<T>) -> Unit =
-                clusterContent ?: { DefaultClusterContent(it) }
-            MarkerComposable(
-                cluster.size,
-                state = rememberUpdatedMarkerState(position),
-                zIndex = cluster.items.firstOrNull()?.zIndex ?: 0f,
-                onClick = {
-                    clusterManager.onClusterClick?.invoke(cluster) ?: false
-                },
-            ) {
-                content(cluster)
+            if (markerVisibility?.invoke(position) != false) {
+                val content: @Composable (Cluster<T>) -> Unit =
+                    clusterContent ?: { DefaultClusterContent(it) }
+                MarkerComposable(
+                    cluster.size,
+                    state = rememberUpdatedMarkerState(position),
+                    zIndex = cluster.items.firstOrNull()?.zIndex ?: 0f,
+                    onClick = {
+                        clusterManager.onClusterClick?.invoke(cluster) ?: false
+                    },
+                ) {
+                    content(cluster)
+                }
             }
         },
         itemContent = { item, position ->
-            if (clusterItemContent != null) {
-                MarkerComposable(
-                    item,
-                    state = rememberUpdatedMarkerState(position),
-                    title = item.title,
-                    snippet = item.snippet,
-                    zIndex = item.zIndex ?: 0f,
-                    onClick = {
-                        clusterManager.onClusterItemClick?.invoke(item) ?: false
-                    },
-                    onInfoWindowClick = {
-                        clusterManager.onClusterItemInfoWindowClick?.invoke(item)
-                    },
-                    onInfoWindowLongClick = {
-                        clusterManager.onClusterItemInfoWindowLongClick?.invoke(item)
-                    },
-                ) {
-                    clusterItemContent(item)
+            if (markerVisibility?.invoke(position) != false) {
+                if (clusterItemIcon != null) {
+                    Marker(
+                        state = rememberUpdatedMarkerState(position),
+                        anchor = clusterItemAnchor,
+                        icon = clusterItemIcon(item),
+                        title = item.title,
+                        snippet = item.snippet,
+                        zIndex = item.zIndex ?: 0f,
+                        onClick = {
+                            clusterManager.onClusterItemClick?.invoke(item) ?: false
+                        },
+                        onInfoWindowClick = {
+                            clusterManager.onClusterItemInfoWindowClick?.invoke(item)
+                        },
+                        onInfoWindowLongClick = {
+                            clusterManager.onClusterItemInfoWindowLongClick?.invoke(item)
+                        },
+                    )
+                } else if (clusterItemContent != null) {
+                    // `MarkerComposable` 仅在 key 变化时重建位图；没有额外 key 时
+                    // 复用 item，避免传入 nullable key。
+                    val contentKey = clusterItemContentKey?.invoke(item) ?: item
+                    MarkerComposable(
+                        item,
+                        contentKey,
+                        state = rememberUpdatedMarkerState(position),
+                        title = item.title,
+                        snippet = item.snippet,
+                        zIndex = item.zIndex ?: 0f,
+                        onClick = {
+                            clusterManager.onClusterItemClick?.invoke(item) ?: false
+                        },
+                        onInfoWindowClick = {
+                            clusterManager.onClusterItemInfoWindowClick?.invoke(item)
+                        },
+                        onInfoWindowLongClick = {
+                            clusterManager.onClusterItemInfoWindowLongClick?.invoke(item)
+                        },
+                    ) {
+                        clusterItemContent(item)
+                    }
+                } else {
+                    Marker(
+                        state = rememberUpdatedMarkerState(position),
+                        title = item.title,
+                        snippet = item.snippet,
+                        zIndex = item.zIndex ?: 0f,
+                        onClick = {
+                            clusterManager.onClusterItemClick?.invoke(item) ?: false
+                        },
+                        onInfoWindowClick = {
+                            clusterManager.onClusterItemInfoWindowClick?.invoke(item)
+                        },
+                        onInfoWindowLongClick = {
+                            clusterManager.onClusterItemInfoWindowLongClick?.invoke(item)
+                        },
+                    )
                 }
-            } else {
-                Marker(
-                    state = rememberUpdatedMarkerState(position),
-                    title = item.title,
-                    snippet = item.snippet,
-                    zIndex = item.zIndex ?: 0f,
-                    onClick = {
-                        clusterManager.onClusterItemClick?.invoke(item) ?: false
-                    },
-                    onInfoWindowClick = {
-                        clusterManager.onClusterItemInfoWindowClick?.invoke(item)
-                    },
-                    onInfoWindowLongClick = {
-                        clusterManager.onClusterItemInfoWindowLongClick?.invoke(item)
-                    },
-                )
+                clusterItemDecoration(item, position)
             }
-            clusterItemDecoration(item, position)
         },
     )
 }
@@ -175,6 +215,10 @@ fun <T : ClusterItem> Clustering(
     exitAnimationSpec: FiniteAnimationSpec<Float> = DefaultAnimationSpec,
     clusterContent: (@Composable (Cluster<T>) -> Unit)? = null,
     clusterItemContent: (@Composable (T) -> Unit)? = null,
+    clusterItemContentKey: ((T) -> Any)? = null,
+    clusterItemIcon: ((T) -> BitmapDescriptor?)? = null,
+    clusterItemAnchor: Offset = Offset(0.5f, 1.0f),
+    markerVisibility: ((LatLng) -> Boolean)? = null,
     clusterItemDecoration: @Composable @GoogleMapComposable (T, LatLng) -> Unit = { _, _ -> },
 ) {
     Clustering(
@@ -187,6 +231,10 @@ fun <T : ClusterItem> Clustering(
         exitAnimationSpec = exitAnimationSpec,
         clusterContent = clusterContent,
         clusterItemContent = clusterItemContent,
+        clusterItemContentKey = clusterItemContentKey,
+        clusterItemIcon = clusterItemIcon,
+        clusterItemAnchor = clusterItemAnchor,
+        markerVisibility = markerVisibility,
         clusterItemDecoration = clusterItemDecoration,
         onClusterManager = null,
     )
@@ -207,6 +255,10 @@ fun <T : ClusterItem> Clustering(
     exitAnimationSpec: FiniteAnimationSpec<Float> = DefaultAnimationSpec,
     clusterContent: (@Composable (Cluster<T>) -> Unit)? = null,
     clusterItemContent: (@Composable (T) -> Unit)? = null,
+    clusterItemContentKey: ((T) -> Any)? = null,
+    clusterItemIcon: ((T) -> BitmapDescriptor?)? = null,
+    clusterItemAnchor: Offset = Offset(0.5f, 1.0f),
+    markerVisibility: ((LatLng) -> Boolean)? = null,
     clusterItemDecoration: @Composable @GoogleMapComposable (T, LatLng) -> Unit = { _, _ -> },
     onClusterManager: ((ClusterManager<T>) -> Unit)?,
 ) {
@@ -227,6 +279,10 @@ fun <T : ClusterItem> Clustering(
         exitAnimationSpec = exitAnimationSpec,
         clusterContent = clusterContent,
         clusterItemContent = clusterItemContent,
+        clusterItemContentKey = clusterItemContentKey,
+        clusterItemIcon = clusterItemIcon,
+        clusterItemAnchor = clusterItemAnchor,
+        markerVisibility = markerVisibility,
         clusterItemDecoration = clusterItemDecoration,
     )
 }

--- a/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/RememberComposeBitmapDescriptor.android.kt
+++ b/kmp-maps-compose/src/androidMain/kotlin/eu/buney/maps/RememberComposeBitmapDescriptor.android.kt
@@ -4,10 +4,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalView
 import androidx.core.graphics.applyCanvas
@@ -22,10 +20,12 @@ actual fun rememberComposeBitmapDescriptor(
 ): BitmapDescriptor {
     val parent = LocalView.current as ViewGroup
     val compositionContext = rememberCompositionContext()
-    val currentContent by rememberUpdatedState(content)
 
-    return remember(parent, compositionContext, currentContent, *keys) {
-        renderComposableToBitmapDescriptor(parent, compositionContext, currentContent)
+    // Callers must explicitly include content changes in keys. Using the lambda reference itself
+    // as a key would recreate the ComposeView and bitmap on every recomposition, defeating
+    // the Marker descriptor cache.
+    return remember(parent, compositionContext, *keys) {
+        renderComposableToBitmapDescriptor(parent, compositionContext, content)
     }
 }
 

--- a/sample/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/sample/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3">
-   <BuildAction>
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForRunning = "YES">
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "78B53CC79860CBFC2F5543C6"
@@ -15,11 +21,25 @@
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
-   <LaunchAction
-      useCustomWorkingDirectory = "NO"
+   <TestAction
       buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "78B53CC79860CBFC2F5543C6"
@@ -29,4 +49,18 @@
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/sample/shared/src/commonMain/kotlin/eu/buney/sample/ClusteringScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/eu/buney/sample/ClusteringScreen.kt
@@ -1,5 +1,6 @@
 package eu.buney.sample
 
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.horizontalScroll
@@ -26,23 +27,26 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import co.touchlab.kermit.Logger
 import eu.buney.maps.CameraPosition
+import eu.buney.maps.Circle
 import eu.buney.maps.GoogleMap
 import eu.buney.maps.LatLng
-import eu.buney.maps.utils.clustering.Cluster
+import eu.buney.maps.MarkerInfoWindow
+import eu.buney.maps.rememberBitmapDescriptor
+import eu.buney.maps.rememberCameraPositionState
+import eu.buney.maps.rememberUpdatedMarkerState
 import eu.buney.maps.utils.clustering.ClusterItem
 import eu.buney.maps.utils.clustering.Clustering
-import eu.buney.maps.Circle
-import eu.buney.maps.rememberCameraPositionState
-import eu.buney.maps.MarkerInfoWindow
-import eu.buney.maps.rememberUpdatedMarkerState
-import androidx.compose.animation.core.tween
-import co.touchlab.kermit.Logger
+import mapscomposemultiplatform.sample.shared.generated.resources.Res
+import mapscomposemultiplatform.sample.shared.generated.resources.overlay_image
+import org.jetbrains.compose.resources.ExperimentalResourceApi
 import kotlin.random.Random
 
 private val logger = Logger.withTag("ClusteringScreen")
@@ -53,6 +57,7 @@ private val singapore = LatLng(1.35, 103.87)
 private enum class ClusteringType {
     Default,
     CustomUi,
+    CachedIcon,
     Decorations,
 }
 
@@ -93,6 +98,7 @@ fun ClusteringScreen(modifier: Modifier = Modifier) {
                 when (clusteringType) {
                     ClusteringType.Default -> DefaultClustering(items)
                     ClusteringType.CustomUi -> CustomUiClustering(items)
+                    ClusteringType.CachedIcon -> CachedIconClustering(items)
                     ClusteringType.Decorations -> DecorationsClustering(items)
                 }
 
@@ -163,6 +169,24 @@ private fun CustomUiClustering(items: List<MyItem>) {
                 text = "",
                 color = Color.Red,
             )
+        },
+    )
+}
+
+@OptIn(ExperimentalResourceApi::class)
+@Composable
+private fun CachedIconClustering(items: List<MyItem>) {
+    // Loaded once and reused by every unclustered item. Unlike clusterItemContent,
+    // this does not render a Compose bitmap for each marker during transitions.
+    val vehicleIcon = rememberBitmapDescriptor(Res.drawable.overlay_image)
+
+    Clustering(
+        items = items,
+        clusterItemIcon = { vehicleIcon },
+        clusterItemAnchor = Offset(0.5f, 0.5f),
+        onClusterItemClick = {
+            logger.i { "Cached-icon cluster item clicked! ${it.title}" }
+            false
         },
     )
 }
@@ -240,6 +264,7 @@ private fun ClusteringTypeControls(
                     text = when (type) {
                         ClusteringType.Default -> "Default"
                         ClusteringType.CustomUi -> "Custom UI"
+                        ClusteringType.CachedIcon -> "Cached Icon"
                         ClusteringType.Decorations -> "Decorations"
                     },
                 )


### PR DESCRIPTION
## Summary

This PR improves clustering performance and rendering control for unclustered items, while updating the Android and iOS build tooling.

### Clustering improvements

- Add `clusterItemIcon` for rendering unclustered items with cached `BitmapDescriptor`s, avoiding Compose bitmap generation for each marker.
- Add `clusterItemAnchor` to configure icon placement; it defaults to the pin-friendly `(0.5, 1.0)`.
- Add `clusterItemContentKey` so callers can explicitly control when Compose-backed marker bitmaps are rebuilt.
- Add `markerVisibility` to suppress marker output outside the visible area without affecting cluster calculation or split/merge transitions.
- Update Android bitmap descriptor caching so marker bitmaps are recreated only when explicit keys change.
- Add a cached-icon clustering example and document the new APIs.

### Build tooling

- Update Android Gradle Plugin from `9.1.0` to `9.2.1`.
- Update spm4kmp from `1.7.0` to `1.9.1`.

## Testing

- [ ] `./gradlew publishToMavenLocal --no-configuration-cache`
- [x] Verified the Android sample
- [x] Verified the iOS sample

## Notes

`clusterItemIcon` takes precedence over `clusterItemContent`. Callers should return cached descriptors from `clusterItemIcon` rather than creating them during rendering.
