### PR TITLE
Check and sanitize Klib paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,23 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
 
+      # The cinterop klibs are generated from spm4Kmp def files that reference this runner's build
+      # directory. kmp-maps-compose/build.gradle.kts strips those paths back out; fail loudly if a
+      # change ever lets them through again. See issue #10.
+      - name: Check klibs carry no build-machine paths
+        run: |
+          set -euo pipefail
+          leaked=0
+          while IFS= read -r klib; do
+            manifest=$(unzip -p "$klib" default/manifest)
+            if grep -qE '(/Users/runner|/Applications/Xcode|^libraryPaths=)' <<<"$manifest"; then
+              echo "::error file=$klib::klib manifest contains build-machine paths"
+              grep -nE '(/Users/runner|/Applications/Xcode|^libraryPaths=)' <<<"$manifest"
+              leaked=1
+            fi
+          done < <(find ~/.m2/repository/eu/buney/maps -iname '*cinterop*.klib')
+          exit $leaked
+
       - name: Publish to Maven Central
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true'
         run: ./gradlew publishToMavenCentral --no-configuration-cache

--- a/kmp-maps-compose/build.gradle.kts
+++ b/kmp-maps-compose/build.gradle.kts
@@ -1,5 +1,11 @@
 import io.github.frankois944.spmForKmp.swiftPackageConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.CInteropProcess
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -83,6 +89,24 @@ kotlin {
     }
 }
 
+// spm4Kmp writes the absolute Swift package build directory of the machine running cinterop straight
+// into the generated .def file, and cinterop copies those options verbatim into the klib manifest. On
+// a consumer's machine the paths do not exist, so every release so far shipped manifests carrying
+// `-I/-L/-F "/Users/runner/work/..."` and `"/Applications/Xcode_<version>.app/..."`, which surface as
+// confusing `ld: warning: search path ... not found` lines. Strip them so the published klibs are
+// relocatable: the Swift bridge archive is embedded inside the klib itself (default/targets/<target>/
+// included/libGoogleMapsBridge.a), and none of the removed options contribute an actual link input.
+// See https://github.com/yankeppey/kmp-maps-compose/issues/10
+val sanitizeKlibManifests =
+    providers.gradleProperty("kmpMaps.sanitizeKlibManifests").map(String::toBoolean).getOrElse(true)
+
+tasks.withType<CInteropProcess>().configureEach {
+    val klib = klibOutput
+    doLast {
+        if (sanitizeKlibManifests) stripBuildMachinePaths(klib.get())
+    }
+}
+
 mavenPublishing {
     publishToMavenCentral()
     signAllPublications()
@@ -115,3 +139,47 @@ mavenPublishing {
         }
     }
 }
+
+val klibManifestEntry = "default/manifest"
+
+/** Matches a `-I`, `-L` or `-F` option pointing at an absolute path, quoted or bare. */
+val absolutePathOption = Regex("""\s*-[ILF]\s*(?:"/[^"]*"|/\S+)""")
+
+/** Rewrites the manifest of [klib] in place, dropping every build-machine-specific path. */
+fun stripBuildMachinePaths(klib: File) {
+    if (klib.isDirectory) {
+        val manifest = klib.resolve(klibManifestEntry)
+        manifest.writeText(sanitizeKlibManifest(manifest.readText()))
+        return
+    }
+
+    val rewritten = File.createTempFile(klib.nameWithoutExtension, ".klib", klib.parentFile)
+    ZipFile(klib).use { zip ->
+        ZipOutputStream(rewritten.outputStream().buffered()).use { out ->
+            for (entry in zip.entries()) {
+                out.putNextEntry(ZipEntry(entry.name))
+                if (entry.name == klibManifestEntry) {
+                    val manifest = zip.getInputStream(entry).use { it.readBytes() }.decodeToString()
+                    out.write(sanitizeKlibManifest(manifest).toByteArray())
+                } else {
+                    zip.getInputStream(entry).use { it.copyTo(out) }
+                }
+                out.closeEntry()
+            }
+        }
+    }
+    Files.move(rewritten.toPath(), klib.toPath(), StandardCopyOption.REPLACE_EXISTING)
+}
+
+fun sanitizeKlibManifest(manifest: String): String =
+    manifest
+        .lineSequence()
+        .filterNot { it.startsWith("libraryPaths=") }
+        .map { line ->
+            if (line.startsWith("compilerOpts=") || line.startsWith("linkerOpts=")) {
+                line.replace(absolutePathOption, "").trimEnd()
+            } else {
+                line
+            }
+        }
+        .joinToString("\n")


### PR DESCRIPTION
Workaround for #10 

The rootcause is submited to **spm4Kmp**: https://github.com/frankois944/spm4Kmp/issues/328

Until that we could sanitize KLibs path by gradle task and check them in Gitlab workflow.

